### PR TITLE
Int32 int64

### DIFF
--- a/source/transformer/Transformer.hx
+++ b/source/transformer/Transformer.hx
@@ -159,8 +159,8 @@ class Transformer {
             case "go.Float32", "Single": "float32";
             case "go.Float64", "Float": "float64";
             case "Int", "go.GoInt": "int";
-            case "go.Int64", "Int64": "int64";
-            case "go.Int32": "int32";
+            case "haxe.Int64", "go.Int64", "Int64": "int64";
+            case "haxe.Int32", "go.Int32": "int32";
             case "go.Int16": "int16";
             case "go.Int8": "int8";
             case "go.UInt64": "uint64";

--- a/std/haxe/Int32.go.hx
+++ b/std/haxe/Int32.go.hx
@@ -1,0 +1,5 @@
+package haxe;
+
+
+@:go.ProcessedType
+typedef Int32 = go.Int32;

--- a/std/haxe/Int64.go.hx
+++ b/std/haxe/Int64.go.hx
@@ -1,0 +1,4 @@
+package haxe;
+
+@:go.ProcessedType
+typedef Int64 = go.Int64;


### PR DESCRIPTION
Add basic numeric types for Int32 and Int64, set to Go's number types.