### PR TITLE
Create new class instance with type params

### DIFF
--- a/source/transformer/exprs/New.hx
+++ b/source/transformer/exprs/New.hx
@@ -1,5 +1,7 @@
 package transformer.exprs;
 
+import haxe.macro.Expr.TypeParam;
+import haxe.macro.Expr.ComplexType;
 import HaxeExpr;
 import transformer.Transformer;
 import translator.TranslatorTools;
@@ -19,6 +21,7 @@ function transformNew(t:Transformer, e:HaxeExpr, tpath: TypePath, params: Array<
     var isNative = false;
     var transformName = false;
     var name = ''; // TODO: default name
+    var setParams:Array<TypeParam> = [];
 
     switch tpath {
         case { pack: [], name: "Array", params: [TPType(ct)] }:
@@ -28,6 +31,8 @@ function transformNew(t:Transformer, e:HaxeExpr, tpath: TypePath, params: Array<
         case { pack: [], name: "String"}:
             e.def = params[0].def;
             return;
+        case {pack: _, name: _, params: params} if (params != null && params.length > 0):
+            setParams = params;
         case _: null;
     }
 
@@ -71,9 +76,18 @@ function transformNew(t:Transformer, e:HaxeExpr, tpath: TypePath, params: Array<
     }
 
     var className = 'Hx_${modulePathToPrefix(td.name)}_Obj';
+
+    for (param in setParams) {
+        switch param {
+            case TPType(param):
+                t.transformComplexType(param);
+            default:
+        }
+    }
+
     e.def = ECall({
         t: e.t,
-        def: EConst(CIdent('${className}_CreateInstance'))
+        def: EConst(CIdent('${className}_CreateInstance' + t.module.translator.translateComplexTypeParams(setParams)))
     }, params);
 
     for (p in params) {

--- a/source/translator/Translator.hx
+++ b/source/translator/Translator.hx
@@ -142,11 +142,20 @@ class Translator {
     }
 
     public function translateParamDecl(params: Array<TypeParamDecl>): String {
-        return params.length > 0 ? '[${params.map(p -> '${p.name} any').join(', ')}]' : '';
+        return params.length > 0 ? '[${params.map(p -> p.name + " any").join(', ')}]' : '';
     }
 
     public function translateParamUse(params: Array<TypeParamDecl>): String {
-        return params.length > 0 ? '[${params.map(p -> '${p.name}').join(', ')}]' : '';
+        return params.length > 0 ? '[${params.map(p -> p.name).join(', ')}]' : '';
+    }
+
+    public function translateComplexTypeParams(params:Array<TypeParam>):String {
+        return params.length > 0 ? '[${params.map(p -> switch p {
+            case TPType(p):
+                translateComplexType(p);
+            case _:
+                throw "invalid TPExpr";
+        }).join(', ')}]' : '';
     }
 
     public function translateTypeDef(def: HaxeTypeDefinition, ct:ComplexType):String {

--- a/testbed/Test.hx
+++ b/testbed/Test.hx
@@ -1,13 +1,11 @@
+import haxe.Rest;
+
 function main() {
-    var x:String = "ho";
-    Sys.println(x.charAt(1) + x.charCodeAt(0));
-    Sys.println(x.indexOf("o"));
-    Sys.println(x.split(""));
-    Sys.println(String.fromCharCode(42));
-    Sys.println(new String("hi"));
+   var x = new X<Int>();
+   Sys.println(x.a);
 }
 
 class X<T> {
+    public var a:Array<T> = [];
     public function new() {}
-    public var x:T;
 }

--- a/testbed/Test.hx
+++ b/testbed/Test.hx
@@ -1,5 +1,3 @@
-import haxe.Rest;
-
 function main() {
    var x = new X<Int>();
    Sys.println(x.a);


### PR DESCRIPTION
Take the case
```haxe
function main() {
   var x = new X<Int>();
   Sys.println(x.a);
}

class X<T> {
    public var a:Array<T> = [];
    public function new() {}
}
```

Before the type param info wouldn't be able to be inferred and there would be a compile time error on the Go side.
However now with this PR it adds the necessary explicit type param information when calling ``CreateInstance``
```go
func Hx__test_test_fields__Main_Field()  {
    var _temp_0 *[]int = Hx_x_Obj_CreateInstance[int]().A; _ = _temp_0
    Hx_sys_Println_Field(_temp_0)
}
```
