### PR TITLE
Trace

### DIFF
--- a/source/Module.hx
+++ b/source/Module.hx
@@ -1,3 +1,4 @@
+import haxe.macro.Expr.ComplexType;
 import preprocessor.Preprocessor;
 import translator.TranslatorTools.toCamelCase;
 import sys.io.File;
@@ -90,5 +91,28 @@ class Module {
     public function getFile():Context.ContextFile {
         // TODO
         throw "not implemented yet";
+    }
+
+
+    public function follow(ct:ComplexType):ComplexType {
+        return switch ct {
+            case TPath({pack: [], name: "Null", params: [TPType(ct)]}):
+                follow(ct);
+            case TPath(p):
+                final td = resolveClass(p.pack, p.name, path);
+                if (td == null) {
+                    ct;
+                }else{
+                    // trace(td.name);
+                    switch td.kind {
+                        case TDType(ct):
+                            follow(ct);
+                        case _:
+                            ct;
+                    }
+                }
+            default:
+                ct;
+        }
     }
 }

--- a/source/transformer/exprs/ArrayAccess.hx
+++ b/source/transformer/exprs/ArrayAccess.hx
@@ -4,7 +4,7 @@ import haxe.macro.Expr.ComplexType;
 import HaxeExpr.HaxeVar;
 
 function transformArrayAccess(t:Transformer, e: HaxeExpr, e1:HaxeExpr, e2:HaxeExpr) {
-    final ct = HaxeExprTools.stringToComplexType(e1.t);
+    final ct = t.module.follow(HaxeExprTools.stringToComplexType(e1.t));
     switch (ct) {
         case TPath(p):
             switch [p.name, p.pack, p.params] {

--- a/source/transformer/exprs/FieldAccess.hx
+++ b/source/transformer/exprs/FieldAccess.hx
@@ -228,7 +228,7 @@ function handleCallTransform(t:Transformer, e:HaxeExpr, params:Array<HaxeExpr>, 
 }
 
 function handleFieldTransform(t:Transformer, e:HaxeExpr, ct:ComplexType, e2:HaxeExpr, field:String):Bool {
-    var transformed = switch ct {
+    var transformed = switch t.module.follow(ct) {
         case TPath({ name: "Array", pack: [] }) if (field == "length"):
             e.def = EGoCode('len(*{0})', [e2]);
             true;
@@ -252,7 +252,6 @@ function handleFieldTransform(t:Transformer, e:HaxeExpr, ct:ComplexType, e2:Haxe
 
             op.on.def = t.createCallStatic("runtime.HxDynamic", op.name, op.right != null ? [e2, field, op.right] : [e2, field]);
             t.transformExpr(op.on);
-
             true;
 
         case TAnonymous(fields):

--- a/source/translator/exprs/ArrayDeclaration.hx
+++ b/source/translator/exprs/ArrayDeclaration.hx
@@ -5,7 +5,7 @@ import HaxeExpr;
 import haxe.macro.Expr.ComplexType;
 
 function translateArrayDeclaration(t:Translator, e:HaxeExpr, values:Array<HaxeExpr>, ct:ComplexType):String {
-    return if (isMap(ct)) {
+    return if (isMap(t, ct)) {
         translateArrayDeclMap(t, values, ct);
     }else{
         final ctStr = t.translateComplexType(ct);
@@ -48,9 +48,8 @@ function getTypeParams(ct:ComplexType):Array<ComplexType> {
     }
 }
 
-function isMap(ct:ComplexType) {
-    // TODO Context.follow needed in case it's a named alias
-    return switch ct {
+function isMap(t:Translator, ct:ComplexType) {
+    return switch t.module.follow(ct) {
         // anon type -> map[string]any
         case TAnonymous(_):
             true;

--- a/testbed/Test.hx
+++ b/testbed/Test.hx
@@ -1,9 +1,3 @@
 function main() {
-   var x = new X<Int>();
-   Sys.println(x.a);
-}
-
-class X<T> {
-    public var a:Array<T> = [];
-    public function new() {}
+    trace("hello");
 }


### PR DESCRIPTION
Hello world with trace now works! This PR adds a follow function in module, to follow a ComplexType to the underlying version if it's a typedef or ``Null<T> -> T``. This also adds a band aid fix, where it removes casting for both sides if the ``op`` is ``==`` or ``!=`` as no casting makes sense in that context yet, and especially for null equality checks.